### PR TITLE
[Feature] Support the info object

### DIFF
--- a/doc/features/[Feature] Support the info object.md
+++ b/doc/features/[Feature] Support the info object.md
@@ -1,0 +1,173 @@
+#Info Object - Model-first Tooling
+
+##1.	Core JSON Model Info Object fields in Service Object
+The core JSON model uses word service instead of info as the root level container element:
+
+```JSON
+ "service":{
+    "name": "TripPin OData Reference Service"
+    "version": {
+      "current": 0
+    },
+    "description": "TripPin is a fictional reference service demonstrating the capabilities of OData v4."
+    "termsOfService": "http://swagger.io/terms/"
+    "contact": {
+        "name": "API Support"
+        "url": "http://www.swagger.io/support"
+        "email": "support@swagger.io"
+    }
+    "license": {
+        "name": "Apache 2.0"
+        "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+     }
+  }
+```
+
+The following top level element is defined:
+
+----------------------------
+Field Name|	Description
+-----------|----------------
+service	| Provides metadata about the API. The metadata can be used by the clients if needed
+------------------------------------------------------------
+
+Two required fields within service.
+
+----------------------------
+Field Name|	Description
+-----------|----------------
+name	| Required. The title of the application.
+version	| Required. Provides the version of the application API (not to be confused with the specification version).
+------------------------------------------------------------
+
+Two formats of version available:
+
+1. Use current property as showne in the above sample.
+2. Show version numbers directly as the value of version.
+
+```JSON
+version: "1.0"
+```
+
+For other fields within service see section 3.1.
+
+##2.	YAML Format Info Object fields in Service Object
+Simple YAML also uses keyword service instead of info as top level element.
+
+Here is a YAML sample:
+
+```YAML
+service:
+  name: TripPin OData Reference Service
+  version:
+    current: 0
+  description: TripPin is a fictional reference service demonstrating the capabilities of OData v4.
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: API Support
+    url: http://www.swagger.io/support
+    email: support@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+```
+
+The following top level element is defined:
+
+----------------------------
+Field Name|	Description|
+-----------|----------------
+service	| Provides metadata about the API. The metadata can be used by the clients if needed
+------------------------------------------------------------
+
+Two required fields within service.
+
+----------------------------
+Field Name|	Description
+-----------|----------------
+name	| Required. The title of the application.
+version	| Required. Provides the version of the application API (not to be confused with the specification version).
+------------------------------------------------------------
+
+Two formats of version available:
+
+1. Use current property as showne in the above sample.
+2. Show version numbers directly as the value of version.
+
+```YAML
+version: 1.0
+```
+
+For other fields within service see section 3.1.
+
+##3.	Swagger Format Info Object support
+Swagger is supported as one of the output formats, here converting core model to a Swagger schema uses the one-to-one mapping.
+
+Here is 1 sample of an info element:
+
+```SWAGGER
+info: {
+  "title": "Swagger Sample App",
+  "description": "This is a sample server Petstore server.",
+  "termsOfService": "http://swagger.io/terms/",
+  "contact": {
+    "name": "API Support",
+    "url": "http://www.swagger.io/support",
+    "email": "support@swagger.io"
+  },
+  "license": {
+    "name": "Apache 2.0",
+    "url": "http://www.apache.org/licenses/LICENSE-2.0.html"
+  },
+  "version": "1.0.1"
+}
+```
+
+Here is how JSON model is mapped to a Swagger schema:
+
+----------------------------
+Field Name|	Description|
+-----------|----------------
+info	| The info object for metadata about the API, would be converted from info element from core model. See details below. Corresponds to the service element in simple YAML and JSON model.
+------------------------------------------------------------
+
+###3.1	info Fields
+As per swagger spec, info object element is required and provides metadata about the API. A JSON object contains key-value pair from an info object name to a schema object.
+
+Fixed Fields
+
+----------------------------
+Field Name|	Type |Description
+-----------|-----|-----------
+title	|string|	Required. The title of the application, corresponding to the name field in simple YAML and JSON model.
+description	|string|	A short description of the application. GFM syntax can be used for rich text representation.
+termsOfService	|string|	The Terms of Service for the API.
+contact	|Contact Object| The contact information for the exposed API.
+license	|License Object| The license information for the exposed API.
+version	|string|	Required. Provides the version of the application API (not to be confused with the specification version).
+----------------------------------------------------------------------------------------------
+
+Contact Object
+Contact information for the exposed API.
+
+Fixed Fields
+
+----------------------------
+Field Name|	Type |Description
+-----------|-----|-----------
+name	|string|	The identifying name of the contact person/organization.
+url	|string|	The URL pointing to the contact information. MUST be in the format of a URL.
+email	|string|	The email address of the contact person/organization. MUST be in the format of an email address.
+--------------------------------------------------------------------------------------------------
+
+License Object
+License information for the exposed API.
+
+Fixed Fields
+
+----------------------------
+Field Name|	Type |Description
+-----------|-----|-----------
+name	|string|	Required. The license name used for the API.
+url	|string|	A URL to the license used for the API. MUST be in the format of a URL.
+-------------------------------------------------------------------------------------

--- a/doc/samples/trippin.yaml
+++ b/doc/samples/trippin.yaml
@@ -4,6 +4,14 @@ service:
   version:
     current: 1.0.0
   description: "TripPin is a fictional reference service demonstrating the capabilities of OData v4."
+  termsOfService: http://swagger.io/terms/
+  contact:
+    name: API Support
+    url: http://www.swagger.io/support
+    email: support@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
   auth: none
   conformance: minimal
   supportsFilterFunctions: [contains, endswith, startswith, length, indexof, substring, tolower, toupper, trim, concat, year, month, day, hour, minute, second, round, floor, ceiling, cast, isof]

--- a/src/modules/modSwagger.js
+++ b/src/modules/modSwagger.js
@@ -266,6 +266,21 @@
             'name'  : function(name){
               state.info.title  = name;
             },
+			'version' : function(version){
+				if(version.current || version.current === 0)
+					state.info.version = version.current;
+				else
+					state.info.version = version;
+			},
+			'termsOfService' : function(termsOfService){
+				state.info.termsOfService = termsOfService;
+			},
+			'contact' : function(obj){
+				state.info.contact= obj;
+			},
+			'license' : function(obj){
+				state.info.license = obj;
+			},
             'description' : function(description){
               state.info.description = description;
             },

--- a/test/modules/modSwaggerSpec.js
+++ b/test/modules/modSwaggerSpec.js
@@ -6,6 +6,7 @@ describe('[Swagger] To Swagger test', function() {
       {
         'service':{
           'name' : 'service1',
+		  'version' : '0.1',
           'description' : 'this is service1',
           'host': 'var1.org',
           'basePath': '/ab/(S(cnbm44wtbc1v5bgrlek5lpcc))/dat'
@@ -24,6 +25,47 @@ describe('[Swagger] To Swagger test', function() {
     expect('\n' + JSON.stringify(sw.basePath)).toEqual('\n' + '"/ab/(S(cnbm44wtbc1v5bgrlek5lpcc))/dat"');
   });
 
+  it('Info object related service fields should match', function() {
+    var jsonModel = 
+      {
+		'service': {
+		  'name': 'TripPin OData Reference Service',
+          'version': {
+            'current': '1.0.0'
+          },
+          'description': 'TripPin is a fictional reference service demonstrating the capabilities of OData v4.',
+          'termsOfService': 'http://swagger.io/terms/',
+          'contact': {
+            'name': 'API Support',
+            'url': 'http://www.swagger.io/support',
+            'email': 'support@swagger.io'
+          },
+          'license': {
+            'name': 'Apache 2.0',
+            'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+          },
+	    }
+	  };
+
+    var expected  = {
+		'title': 'TripPin OData Reference Service',
+		'version': '1.0.0',
+		'description': 'TripPin is a fictional reference service demonstrating the capabilities of OData v4.',
+		'termsOfService': 'http://swagger.io/terms/',
+		'contact': {
+		  'name': 'API Support',
+		  'url': 'http://www.swagger.io/support',
+		  'email': 'support@swagger.io'
+		},
+		'license': {
+		  'name': 'Apache 2.0',
+		  'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+		}
+	};
+
+    assertService(jsonModel, expected);
+  });
+  
   it('Definitions should work.', function() {
     var jsonModel = 
       {
@@ -358,6 +400,10 @@ function assertDefinition(input, output){
 
 function assertPaths(input, output){
   expect('\n' + toSwagger(input, 'paths')).toEqual('\n' + JSON.stringify(output));
+}
+
+function assertService(input, output){
+  expect('\n' + toSwagger(input, 'info')).toEqual('\n' + JSON.stringify(output));
 }
 
 function toSwagger(input, section, returnJson){

--- a/test/modules/modYamlSpec.js
+++ b/test/modules/modYamlSpec.js
@@ -3,12 +3,52 @@
 describe('[YAML] Service section test', function() {
   var input='\
 service:\n\
-  name: Service0\n';
+  name: Service0\n\
+  version: 3';
 
   it('Service name should match', function() {
     var model = Morpho.convertFrom.yaml.call(Morpho, input, {}, {});
     expect(model.service.name).toEqual('Service0');
   });
+  
+  it('Service version without current format should match', function() {
+    var model = Morpho.convertFrom.yaml.call(Morpho, input, {}, {});
+    expect(model.service.version).toEqual(3);
+  });
+  
+  it('Service info object fields should match', 
+    fromYamlServiceTest(
+	'service:\n\
+  name: TripPin OData Reference Service\n\
+  version:\n\
+    current: 1.2.3\n\
+  description: TripPin is a fictional reference service demonstrating the capabilities of OData v4.\n\
+  termsOfService: http://swagger.io/terms/\n\
+  contact:\n\
+    name: API Support\n\
+    url: http://www.swagger.io/support\n\
+    email: support@swagger.io\n\
+  license:\n\
+    name: Apache 2.0\n\
+    url: http://www.apache.org/licenses/LICENSE-2.0.html',
+	{
+    'name': 'TripPin OData Reference Service',
+    'version': {
+      'current': '1.2.3'
+    },
+    'description': 'TripPin is a fictional reference service demonstrating the capabilities of OData v4.',
+    'termsOfService': 'http://swagger.io/terms/',
+    'contact': {
+      'name': 'API Support',
+      'url': 'http://www.swagger.io/support',
+      'email': 'support@swagger.io'
+    },
+    'license': {
+      'name': 'Apache 2.0',
+      'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
+	}
+    })
+  );
 });
 
 describe('[YAML] Type section test', function() {
@@ -145,6 +185,11 @@ function fromYamlRootTest(input, root)
 function fromYamlTypeTest(input, types, addDefaults)
 {
   return fromYamlTest(input, types, 'types', addDefaults);
+}
+
+function fromYamlServiceTest(input, service, addDefaults)
+{
+  return fromYamlTest(input, service, 'service', addDefaults);
 }
 
 function fromYamlTest(input, json, section, addDefaults){


### PR DESCRIPTION
1.	Convert from YAML to Json EDM
2.	Convert from Json EDM to Swagger

Changes include: javascript code, unit tests, design document and sample file of the feature.