### PR TITLE
Optimize type definitions in Model-first

### DIFF
--- a/src/conventions/convAddDefaults.js
+++ b/src/conventions/convAddDefaults.js
@@ -8,7 +8,7 @@ Morpho.addDefaults = function(model)
           'properties' : function(properties){
             visitor.visitArr(properties, function(property){
               if(!property.type){
-                property.type = 'String';
+                property.type = 'edm.string';
               }
             });
           }

--- a/src/modules/modSwagger.js
+++ b/src/modules/modSwagger.js
@@ -5,6 +5,62 @@
     }
 
     var SwaggerTypes = {
+        // Types are defined in Swagger Spec. 
+        'edm.int32': new SwaggerType('integer', 'int32'),
+        'edm.int64': new SwaggerType('integer', 'int64'),
+        'edm.single': new SwaggerType('number', 'float'),
+        'edm.double': new SwaggerType('number', 'double'),
+        'edm.string': new SwaggerType('string', undefined),
+        'edm.byte': new SwaggerType('string', 'byte'),
+        'edm.binary': new SwaggerType('string', 'binary'),
+        'edm.boolean': new SwaggerType('boolean', undefined),
+        'edm.date': new SwaggerType('string', 'date'),
+        // Extention types are not defined in Swagger Spec.
+        'edm.decimal': new SwaggerType('number', 'decimal'),
+        'edm.int16': new SwaggerType('integer', 'int16'),
+        'edm.sbyte': new SwaggerType('integer', 'sbyte') 
+    };
+
+    var typeMap = {
+        'edm.datetimeoffset': 'dateTimeOffset',
+        'edm.duration': 'duration',
+        'edm.guid': 'guid',
+        'edm.stream': 'stream',
+        'edm.timeofday': 'timeOfDay',
+        'edm.geography': 'geography',
+        'edm.geographypoint': 'geographyPoint',
+        'edm.geographylinestring': 'geographyLineString',
+        'edm.geographypolygon': 'geographyPolygon',
+        'edm.geographymultipoint': 'geographyMultiPoint',
+        'edm.geographymultilinestring': 'geographyMultiLineString',
+        'edm.geographymultipolygon': 'geographyMultiPolygon',
+        'edm.geographycollection': 'geographyCollection',
+        'edm.geometry': 'geometry',
+        'edm.geometrypoint': 'geometryPoint',
+        'edm.geometrylinestring': 'geometryLineString',
+        'edm.geometrypolygon': 'geometryPolygon',
+        'edm.geometrymultipoint': 'geometryMultiPoint',
+        'edm.geometrymultilinestring': 'geometryMultiLineString',
+        'edm.geometrymultipolygon': 'geometryMultiPolygon',
+        'edm.geometrycollection': 'geometryCollection'
+    };
+
+    function getSwaggerType(type, isCollection) {
+        var swgrType;
+        if(SwaggerTypes[type]){
+            swgrType = SwaggerTypes[type];
+        }
+        else if(typeMap[type]){
+            swgrType = new SwaggerType('string', 'string');
+        }
+        else{
+            swgrType = { '$ref': '#/definitions/' + type };
+        }
+
+        return isCollection ? { 'type': 'array', 'items': swgrType } : swgrType;
+    }
+
+    /*var SwaggerTypes = {
         'integer': new SwaggerType('integer', 'int32'),
         'long': new SwaggerType('integer', 'int64'),
         'float': new SwaggerType('number', 'float'),
@@ -41,11 +97,11 @@
         // 'Stream': 'Edm.Stream',
         'String': SwaggerTypes.string,
         // 'TimeOfDay': 'Edm.TimeOfDay',
-    };
+    };*/
 
     var entitySetMappings = {};
 
-    function getSwaggerType(type, isCollection) {
+    /*function getSwaggerType(type, isCollection) {
         var sType = type === undefined ?
             SwaggerTypes.string :
             typeMap[type];
@@ -59,7 +115,7 @@
         }
 
         return isCollection ? {'type': 'array', 'items': sType} : sType;
-    }
+    }*/
 
     // Gets a singleton/entity-set's name.
     // params:

--- a/src/modules/modSwagger.js
+++ b/src/modules/modSwagger.js
@@ -60,62 +60,7 @@
         return isCollection ? { 'type': 'array', 'items': swgrType } : swgrType;
     }
 
-    /*var SwaggerTypes = {
-        'integer': new SwaggerType('integer', 'int32'),
-        'long': new SwaggerType('integer', 'int64'),
-        'float': new SwaggerType('number', 'float'),
-        'double': new SwaggerType('number', 'double'),
-        'string': new SwaggerType('string', undefined),
-        'byte': new SwaggerType('string', 'byte'),
-        'boolean': new SwaggerType('boolean', undefined),
-        'date': new SwaggerType('string', 'date'),
-        'dateTime': new SwaggerType('string', 'date-time'),
-        'password': new SwaggerType('string', 'password'),
-        // The follwing types are not defined in Swagger schema
-        'decimal': new SwaggerType('number', 'decimal'),
-        'short': new SwaggerType('number', 'int16'),
-        'guid': new SwaggerType('string', 'guid'),
-        'dateTimeOffset': new SwaggerType('string', 'dateTimeOffset'),
-        'duration': new SwaggerType('string', 'duration'),
-    };
-
-    var typeMap = {
-        'Binary': undefined,
-        'Boolean': SwaggerTypes.boolean,
-        'Byte': SwaggerTypes.byte,
-        'Date': SwaggerTypes.date,
-        'DateTimeOffset': SwaggerTypes.dateTimeOffset,
-        'Decimal': SwaggerTypes.decimal,
-        'Double': SwaggerTypes.double,
-        'Duration': SwaggerTypes.duration,
-        'Guid': SwaggerTypes.guid,
-        'Int16': SwaggerTypes.short,
-        'Int32': SwaggerTypes.integer,
-        'Int64': SwaggerTypes.long,
-        // 'SByte'   : 'Edm.SByte',
-        'Single': SwaggerTypes.float,
-        // 'Stream': 'Edm.Stream',
-        'String': SwaggerTypes.string,
-        // 'TimeOfDay': 'Edm.TimeOfDay',
-    };*/
-
     var entitySetMappings = {};
-
-    /*function getSwaggerType(type, isCollection) {
-        var sType = type === undefined ?
-            SwaggerTypes.string :
-            typeMap[type];
-
-        if (!sType) {
-            if (type.length > 4 && type.slice(0, 4) === 'edm.') {
-                sType = new SwaggerType('string', type);
-            } else {
-                sType = {'$ref': '#/definitions/' + type};
-            }
-        }
-
-        return isCollection ? {'type': 'array', 'items': sType} : sType;
-    }*/
 
     // Gets a singleton/entity-set's name.
     // params:

--- a/src/modules/modYaml.js
+++ b/src/modules/modYaml.js
@@ -11,29 +11,6 @@ function fromYaml(str, errors, config) {
         return null;
     }
 
-    /*var typeMap =
-    {
-        'binary': 'Binary',
-        'bool': 'Boolean',
-        'byte': 'Byte',
-        'date': 'Date',
-        'dateTimeOffset': 'DateTimeOffset',
-        'decimal': 'Decimal',
-        'double': 'Double',
-        'duration': 'Duration',
-        'guid': 'Guid',
-        'short': 'Int16',
-        'int16': 'Int16',
-        'int': 'Int32',
-        'int32': 'Int32',
-        'long': 'Int64',
-        'int64': 'Int64',
-        'sbyte': 'SByte',
-        'single': 'Single',
-        'stream': 'Stream',
-        'string': 'String',
-        'timeOfDay': 'TimeOfDay',
-    };*/
     var typeMap = {
         'binary': 'edm.binary',
         'bool': 'edm.boolean',

--- a/src/modules/modYaml.js
+++ b/src/modules/modYaml.js
@@ -134,13 +134,13 @@ function fromYaml(str, errors, config) {
                 else if (arr[i].name && !arr[i].type) {
                     tempObj = {
                         'name': arr[i].name,
-                        'type': 'String'
+                        'type': 'edm.string'
                     };
                 }
                 else {
                     tempObj = {
                         'name': arr[i],
-                        'type': 'String'
+                        'type': 'edm.string'
                     };
                 }
                 tempArr.push(tempObj);
@@ -149,7 +149,7 @@ function fromYaml(str, errors, config) {
         else {
             var tempObj = {
                 'name': arr,
-                'type': 'String'
+                'type': 'edm.string'
             };
             tempArr.push(tempObj);
         }

--- a/src/modules/modYaml.js
+++ b/src/modules/modYaml.js
@@ -11,7 +11,7 @@ function fromYaml(str, errors, config) {
         return null;
     }
 
-    var typeMap =
+    /*var typeMap =
     {
         'binary': 'Binary',
         'bool': 'Boolean',
@@ -33,7 +33,75 @@ function fromYaml(str, errors, config) {
         'stream': 'Stream',
         'string': 'String',
         'timeOfDay': 'TimeOfDay',
-    };
+    };*/
+    var typeMap = {
+        'binary': 'edm.binary',
+        'bool': 'edm.boolean',
+        'boolean': 'edm.boolean',
+        'byte': 'edm.byte',
+        'date': 'edm.date',
+        'datetimeoffset': 'edm.datetimeoffset',
+        'decimal': 'edm.decimal',
+        'double': 'edm.double',
+        'duration': 'edm.duration',
+        'guid': 'edm.guid',
+        'short': 'edm.int16',
+        'int': 'edm.int32',
+        'integer': 'edm.int32',
+        'long': 'edm.int64',
+        'sbyte': 'edm.sbyte',
+        'float': 'edm.single',
+        'single': 'edm.single',
+        'stream': 'edm.stream',
+        'string': 'edm.string',
+        'timeofday': 'edm.timeofday',
+        'geography': 'edm.geography',
+        'geographypoint': 'edm.geographypoint',
+        'geographylinestring': 'edm.geographylinestring',
+        'geographypolygon': 'edm.geographypolygon',
+        'geographymultipoint': 'edm.geographymultipoint',
+        'geographymultilinestring': 'edm.geographymultilinestring',
+        'geographymultipolygon': 'edm.geographymultipolygon',
+        'geographycollection': 'edm.geographycollection',
+        'geometry': 'edm.geometry',
+        'geometrypoint': 'edm.geometrypoint',
+        'geometrylinestring': 'edm.geometrylinestring',
+        'geometrypolygon': 'edm.geometrypolygon',
+        'geometrymultipoint': 'edm.geometrymultipoint',
+        'geometrymultilinestring': 'edm.geometrymultilinestring',
+        'geometrymultipolygon': 'edm.geometrymultipolygon',
+        'geometrycollection': 'edm.geometrycollection'
+    }
+
+    function matches(type){
+        for(var index in typeMap){
+            if(typeMap[index] === type){
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    function maps(type){
+        var t = type.toLowerCase();
+        if(typeMap[t]){
+            return typeMap[t];
+        }
+        else if(t.length > 4 && t.slice(0, 4) === 'edm.'){
+            if(matches(t)){
+                return t;
+            }
+
+            return type;
+        }
+        else if(matches('edm.' + t)){
+            return 'edm.' + t;
+        }
+        else{
+            return type;
+        }
+    }
 
     function detectCollectionType(yamlType) {
         var type, col;
@@ -60,7 +128,7 @@ function fromYaml(str, errors, config) {
                 if (arr[i].name && arr[i].type) {
                     tempObj = {
                         'name': arr[i].name,
-                        'type': typeMap[arr[i].type] || arr[i].type
+                        'type': maps(arr[i].type)
                     };
                 }
                 else if (arr[i].name && !arr[i].type) {
@@ -112,7 +180,7 @@ function fromYaml(str, errors, config) {
                     },
                     'returns': function (obj) {
                         if (obj) {
-                            operation.returns = typeMap[obj] || obj;
+                            operation.returns = maps(obj);
                         }
                     }
                 });
@@ -159,7 +227,7 @@ function fromYaml(str, errors, config) {
                         property = {'name': obj.name};
                         if (obj.type) {
                             var typeInfo = detectCollectionType(obj.type);
-                            property.type = typeMap[typeInfo.type] || typeInfo.type;
+                            property.type = maps(typeInfo.type);
                             if (typeInfo.isCol) {
                                 property.isCollection = typeInfo.isCol;
                             }
@@ -206,7 +274,7 @@ function fromYaml(str, errors, config) {
 
                         // Parse return type.
                         if (obj.returns) {
-                            operation.returns = typeMap[obj.returns] || obj.returns;
+                            operation.returns = maps(obj.returns);
                         }
 
                         // Parse operation-type (Bound/Unbound).


### PR DESCRIPTION
1. Fix bug #32 [Optimize Design] Type definition should follow some rules (case sensitive) in simple YAML.
2. Fix bug #33 [Optimize Design] There have some types are not supported by Model-first.