### PR TITLE
Error handling bugs

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,8 @@
   "browser": true,
   "globals": {
     "Morpho": false,
-    "CodeMirror" : false    
+    "CodeMirror" : false,
+    "yaml": false
   }
 }
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -11,6 +11,7 @@ module.exports = function(grunt) {
         'src/**/*.js',
         'test/**/*.js',
         'app/**/*.js',
+        '!src/index.js',
         '!bower_components/**',
         '!app/bower_components/**'
       ]

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -1,7 +1,7 @@
 'use strict';
 
 $(function (){
-  function positionRangeForPath(yamlSpec, path, cb) {
+  function positionRangeForPath(yamlSpec, path) {
   var MAP_TAG = 'tag:yaml.org,2002:map';
   var SEQ_TAG = 'tag:yaml.org,2002:seq';
     // Type check
@@ -10,9 +10,6 @@ $(function (){
     }
     if (!Array.isArray(path)) {
       throw new TypeError('path should be an array of strings');
-    }
-    if (typeof cb !== 'function') {
-      throw new TypeError('cb should be a function.');
     }
 
     var invalidRange = {
@@ -25,7 +22,7 @@ $(function (){
 
       // simply walks the tree using current path recursively to the point that
       // path is empty.
-      find(ast);
+      return find(ast);
 
       function find(current) {
         if (current.tag === MAP_TAG) {
@@ -52,10 +49,10 @@ $(function (){
 
         // if path is still not empty we were not able to find the node
         if (path.length) {
-          return cb(invalidRange);
+          return invalidRange;
         }
 
-        return cb({
+        return {
           /* jshint camelcase: false */
           start: {
             line: current.start_mark.line,
@@ -65,11 +62,11 @@ $(function (){
             line: current.end_mark.line,
             column: current.end_mark.column
           }
-        });
+        };
       }
     }
 
-    compose(null, yaml.compose(yamlSpec));
+    return compose(null, yaml.compose(yamlSpec));
   }
 
   function convert(){
@@ -89,9 +86,8 @@ $(function (){
           error.ln=errors[index].lineNumber;
         } else {
           error.errorType = 'Simple Yaml Error';
-          positionRangeForPath(input, errors[index].path,function(range){
-            error.ln = range.start.line + 1;
-          });
+          var range = positionRangeForPath(input, errors[index].path);
+          error.ln = range.start.line + 1;
         }
         console.log(error.errDes);
         var t = $('#errorTemp').tmpl(error);

--- a/app/scripts/editor.js
+++ b/app/scripts/editor.js
@@ -89,8 +89,7 @@ $(function (){
           error.ln=errors[index].lineNumber;
         } else {
           error.errorType = 'Simple Yaml Error';
-          positionRangeForPath(input, errors[index].path,
-            function(range){
+          positionRangeForPath(input, errors[index].path,function(range){
             error.ln = range.start.line + 1;
           });
         }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,10 +17,11 @@ module.exports = function(config) {
     ],
 
     exclude: [],
-    reporters: ['progress'],
+    reporters: ['spec'],
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['PhantomJS'],
-    singleRun: true
+    browsers: ['Chrome'],
+    singleRun: false,
+    port: 9001
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -17,11 +17,10 @@ module.exports = function(config) {
     ],
 
     exclude: [],
-    reporters: ['spec'],
+    reporters: ['progress'],
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
-    singleRun: false,
-    port: 9001
+    browsers: ['PhantomJS'],
+    singleRun: true,
   });
 };

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -21,6 +21,6 @@ module.exports = function(config) {
     logLevel: config.LOG_INFO,
     autoWatch: true,
     browsers: ['PhantomJS'],
-    singleRun: true,
+    singleRun: true
   });
 };

--- a/src/modules/modYaml.js
+++ b/src/modules/modYaml.js
@@ -1,10 +1,12 @@
 function fromYaml(str, errors, config, callback){
   function OnMessage(message){
-    callback(message.data.errors);
+    if(!!callback && typeof callback == 'function')
+    {callback(message.data.errors);}
   }
 
   function OnError(message){
-    callback(message.data.errors);
+    if(!!callback && typeof callback == 'function')
+    {callback(message.data.errors);}
   }
 
   var obj;
@@ -19,8 +21,13 @@ function fromYaml(str, errors, config, callback){
     }]);
     return null;
   }
+  var workerPath = 'bower_components/morpho/src/index.js';
+  if(/^\?id=/.test(window.location.search)|| /^\/debug.html/.test(window.location.pathname))
+  {
+    workerPath = 'base/src/index.js';
+  }
 
-  var worker = worker || new Worker('../bower_components/morpho/src/index.js');
+  var worker = worker || new Worker(workerPath);
   worker.onmessage = OnMessage;
   worker.onerror = OnError;
   worker.postMessage({

--- a/test/modules/modYamlSpec.js
+++ b/test/modules/modYamlSpec.js
@@ -467,13 +467,16 @@ types:\n\
       -name: p1\n\
         type: long\n\
       - p2';
-        var output = Morpho.convert(input, 'yaml', 'json');
-        expect(output.errors.length).toEqual(1);
-        var error = output.errors[0];
-        expect(error.line).toEqual(4);
-        expect(error.message).toEqual('bad indentation of a mapping entry');
+        Morpho.convert(input, 'yaml', 'json', defaultConfig, function(errors){
+          expect(errors.length).toEqual(1);
+          var error = errors[0];
+          expect(error.lineNumber).toEqual(4);
+          expect(error.message).toEqual('bad indentation of a mapping entry');
+        });
     });
 });
+
+var defaultConfig = {addDefaults: true, format: true};
 
 function fromYamlRootTest(input, root) {
     return fromYamlTest(input, root, 'container');


### PR DESCRIPTION
1. Fix the bug #52 :  Fix the warnings reported by JSHint.
2. Fix the bug #53 : Support more properties in simple yaml api section (termsOfService, contact, license)
3. Fix the bug #54 : Support baseType in error handling.
4. Fix the bug #55 : Check only entity type can be used as service type.(report error when using enum type and complex type)
5. Fix the bug #56 : Fix the bug that error handling can't work when running in testing mode.
6. Fix the bug #57 : Over write the test case for [YAML] Error test.
