### PR TITLE
Resolve #84 Default version 0.0.0.0 and add a namespace field in api object

### DIFF
--- a/doc/features/[Feature] Support the info object.md
+++ b/doc/features/[Feature] Support the info object.md
@@ -39,7 +39,7 @@ Field Name|	Description
 -----------|----------------
 name	| Required. The title of the application.
 version	| Required. Provides the version of the application API (not to be confused with the specification version). Default value is "0.0.0.0".
-namespace | Required. The namespace of the application API. Corresponding to the Namespace attribute in [CSDL Section 5.1.1 Attribute Namespace](http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part3-csdl/odata-v4.0-errata02-os-part3-csdl-complete.html#_Toc406397948)) Default value is "Default.Namespace".
+namespace | Required. The namespace of the application API. Corresponding to the Namespace attribute in [CSDL Section 5.1.1 Attribute Namespace](http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part3-csdl/odata-v4.0-errata02-os-part3-csdl-complete.html#_Toc406397948) Default value is "Default.Namespace".
 ------------------------------------------------------------
 
 Two formats of version available:

--- a/doc/features/[Feature] Support the info object.md
+++ b/doc/features/[Feature] Support the info object.md
@@ -10,6 +10,7 @@ The core JSON model uses word api instead of info as the root level container el
       "current": 0
     },
     "description": "TripPin is a fictional reference service demonstrating the capabilities of OData v4."
+    "namespace": "Microsoft.OData.SampleService.Models.TripPin"
     "termsOfService": "http://swagger.io/terms/"
     "contact": {
         "name": "API Support"
@@ -31,13 +32,14 @@ Field Name|	Description
 api	| Provides metadata about the API. The metadata can be used by the clients if needed
 ------------------------------------------------------------
 
-Two required fields within api.
+Three required fields within api.
 
 ----------------------------
 Field Name|	Description
 -----------|----------------
 name	| Required. The title of the application.
-version	| Required. Provides the version of the application API (not to be confused with the specification version).
+version	| Required. Provides the version of the application API (not to be confused with the specification version). Default value is "0.0.0.0".
+namespace | Required. The namespace of the application API. Default value is "Default.Namespace".
 ------------------------------------------------------------
 
 Two formats of version available:
@@ -60,8 +62,9 @@ Here is a YAML sample:
 api:
   name: TripPin OData Reference Service
   version:
-    current: 0
+    current: 0.0.0.0
   description: TripPin is a fictional reference service demonstrating the capabilities of OData v4.
+  namespace: Microsoft.OData.SampleService.Models.TripPin
   termsOfService: http://swagger.io/terms/
   contact:
     name: API Support
@@ -80,13 +83,14 @@ Field Name|	Description|
 api	| Provides metadata about the API. The metadata can be used by the clients if needed
 ------------------------------------------------------------
 
-Two required fields within api.
+Three required fields within api.
 
 ----------------------------
 Field Name|	Description
 -----------|----------------
 name	| Required. The title of the application.
-version	| Required. Provides the version of the application API (not to be confused with the specification version).
+version	| Required. Provides the version of the application API (not to be confused with the specification version). Default value is "0.0.0.0".
+namespace | Required. The namespace of the application API. Default value is "Default.Namespace".
 ------------------------------------------------------------
 
 Two formats of version available:
@@ -101,7 +105,9 @@ version: 1.0
 For other fields within api see section 3.1.
 
 ##3.	Swagger Format Info Object support
-Swagger is supported as one of the output formats, here converting core model to a Swagger schema uses the one-to-one mapping.
+Swagger is supported as one of the output formats, here converting core model to a Swagger schema uses the one-to-one mapping. 
+
+Note: Swagger does not have the namespace field in the info object.
 
 Here is 1 sample of an info element:
 
@@ -144,8 +150,8 @@ description	|string|	A short description of the application. GFM syntax can be u
 termsOfService	|string|	The Terms of Service for the API.
 contact	|Contact Object| The contact information for the exposed API.
 license	|License Object| The license information for the exposed API.
-version	|string|	Required. Provides the version of the application API (not to be confused with the specification version).
-----------------------------------------------------------------------------------------------
+version	|string|	Required. Provides the version of the application API (not to be confused with the specification version). Default value is "0.0.0.0".
+----------------------------------------------------------------------------------------------------------------------------------------
 
 Contact Object
 Contact information for the exposed API.

--- a/doc/features/[Feature] Support the info object.md
+++ b/doc/features/[Feature] Support the info object.md
@@ -39,7 +39,7 @@ Field Name|	Description
 -----------|----------------
 name	| Required. The title of the application.
 version	| Required. Provides the version of the application API (not to be confused with the specification version). Default value is "0.0.0.0".
-namespace | Required. The namespace of the application API. Default value is "Default.Namespace".
+namespace | Required. The namespace of the application API. Corresponding to the Namespace attribute in [CSDL Section 5.1.1 Attribute Namespace](http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part3-csdl/odata-v4.0-errata02-os-part3-csdl-complete.html#_Toc406397948)) Default value is "Default.Namespace".
 ------------------------------------------------------------
 
 Two formats of version available:

--- a/doc/samples/trippin.yaml
+++ b/doc/samples/trippin.yaml
@@ -4,6 +4,7 @@ api:
   version:
     current: 1.0.0
   description: "TripPin is a fictional reference service demonstrating the capabilities of OData v4."
+  namespace: "Microsoft.OData.SampleService.Models.TripPin"
   termsOfService: http://swagger.io/terms/
   contact:
     name: API Support

--- a/src/codegen/modules/csharpClientCodegen.js
+++ b/src/codegen/modules/csharpClientCodegen.js
@@ -700,6 +700,10 @@ function codegen(jObj, namespaceName) {
         if (api.description) {
             result += util.format(' * Description: %s\n', api.description);
         }
+        if (api.namespace){
+            result += util.format(' * Namespace: %s\n', api.namespace);
+            MetadataNamespace = api.namespace;
+        }
         if (api.conformance) {
             result += util.format(' * Conformance-Level: %s\n', api.conformance);
         }

--- a/src/modules/modSwagger.js
+++ b/src/modules/modSwagger.js
@@ -465,7 +465,7 @@
             'swagger': '2.0',
             'info': {
                 'title': 'Demo',
-                'version': '0.1'
+                'version': '0.0.0.0'
             },
             'paths': {}
         };

--- a/src/modules/modYaml.js
+++ b/src/modules/modYaml.js
@@ -255,6 +255,16 @@ function fromYaml(str, errors, config, callback) {
     var state = {};
     visitor.visitObj(obj, {
         'api': function (obj) {
+            if(!obj.version)
+            {
+                obj.version = {current: '0.0.0.0'};
+            }
+            
+            if(!obj.namespace)
+            {
+                obj.namespace = 'Default.Namespace';
+            }
+            
             state.api = obj;
         },
         'types': function (arr) {

--- a/test/modules/modSwaggerSpec.js
+++ b/test/modules/modSwaggerSpec.js
@@ -223,7 +223,7 @@ describe('[Swagger] To Swagger test', function () {
 
         var info = {
             'title': 'host',
-            'version': '0.1',
+            'version': '0.0.0.0',
             'schemes': ['http'],
             'host': 'odata.org',
             'basePath': '/odata'
@@ -269,6 +269,22 @@ describe('[Swagger] To Swagger test', function () {
                 'name': 'Apache 2.0',
                 'url': 'http://www.apache.org/licenses/LICENSE-2.0.html'
             }
+        };
+
+        assertApi(jsonModel, expected);
+    });
+    
+    it('Info default version field should match', function () {
+        var jsonModel =
+                {
+                    'api': {
+                        'name': 'TripPin OData Reference Service',
+                    }
+                };
+
+        var expected = {
+            'title': 'TripPin OData Reference Service',
+            'version': '0.0.0.0'
         };
 
         assertApi(jsonModel, expected);

--- a/test/modules/modYamlSpec.js
+++ b/test/modules/modYamlSpec.js
@@ -6,6 +6,7 @@ api:\n\
   name: TripPin OData Reference Service\n\
   version: 3\n\
   description: TripPin is a fictional reference service demonstrating the capabilities of OData v4.\n\
+  namespace: Microsoft.OData.SampleService.Models.TripPin\n\
   termsOfService: http://swagger.io/terms/\n\
   contact:\n\
     name: API Support\n\
@@ -31,6 +32,11 @@ api:\n\
         expect(model.api.description).toEqual('TripPin is a fictional reference service demonstrating the capabilities of OData v4.');
     });
 
+    it('Api namespace should match', function () {
+        var model = Morpho.convertFrom.yaml.call(Morpho, input, {}, {});
+        expect(model.api.namespace).toEqual('Microsoft.OData.SampleService.Models.TripPin');
+    });
+    
     it('Api termsOfService should match', function () {
         var model = Morpho.convertFrom.yaml.call(Morpho, input, {}, {});
         expect(model.api.termsOfService).toEqual('http://swagger.io/terms/');
@@ -64,6 +70,21 @@ api:\n\
        var model = Morpho.convertFrom.yaml.call(Morpho, inputForVersion, {}, {});
        expect(model.api.version.current).toEqual('1.2.3');
     });
+    
+    var inputForDefaultVersionAndNamespace = '\
+api:\n\
+  name: apiName\n';
+    
+    it ('Api default version should match', function() {
+       var model = Morpho.convertFrom.yaml.call(Morpho, inputForDefaultVersionAndNamespace, {}, {});
+       expect(model.api.version.current).toEqual('0.0.0.0');
+    });
+
+    it ('Api default namespace should match', function() {
+       var model = Morpho.convertFrom.yaml.call(Morpho, inputForDefaultVersionAndNamespace, {}, {});
+       expect(model.api.namespace).toEqual('Default.Namespace');
+    });
+    
 });
 
 describe('[YAML] Primitive type definitions test', function () {


### PR DESCRIPTION
Set default Version field to be '0.0.0.0'.
Set default namespace field to be 'Default.Namespace'. Swagger does not has this field.
Modified areas:
1. YAML to JSON to Swagger code, tests, spec.
2. Let CodeGen read namespace from JSON model. If model does not have the namespace value, the default value in code is TripPin's schema namespace, the same with Luqiang Tian's current code, now.