### PR TITLE
Resolve #104 [model-first, C# codeGen]split bound function namespaces and delete duplicate codes

### DIFF
--- a/src/codegen/modules/csharpClientCodegen.js
+++ b/src/codegen/modules/csharpClientCodegen.js
@@ -4,7 +4,7 @@ var StringHelper = require('../helpers/stringhelper');
 var TypesHelper = require('../helpers/typeshelper');
 
 MetadataNamespace = 'Microsoft.OData.SampleService.Models.TripPin';
-var constants = require('../config').Constants;
+
 var container = require('./entityContainerGenerator');
 
 function hasKeyProperty(type, types){
@@ -768,20 +768,20 @@ function getExBoundFuncReturns(returns, namespaceName, operationName, paramsStr)
 		returnsStr = returns.isCollection && returns.isCollection === true ?
 			util.format('\
 \n\
-            return source.CreateFunctionQuery<%s>("%s.%s", true%s);\n', clrType, constants.Code.DefaultNamespace, operationName, paramsStr) :
+            return source.CreateFunctionQuery<%s>("%s.%s", true%s);\n', clrType, MetadataNamespace, operationName, paramsStr) :
 			util.format('\
 \n\
-            return source.CreateFunctionQuerySingle<%s>("%s.%s", true%s);\n', clrType, constants.Code.DefaultNamespace, operationName, paramsStr);
+            return source.CreateFunctionQuerySingle<%s>("%s.%s", true%s);\n', clrType, MetadataNamespace, operationName, paramsStr);
 	}
 	else{ // isPrimitive === false
 		// Process entity-type.
 		returnsStr = returns.isCollection && returns.isCollection === true ?
 			util.format('\
 \n\
-            return source.CreateFunctionQuery<%s>("%s.%s", true%s);\n', clrType, constants.Code.DefaultNamespace, operationName, paramsStr) :
+            return source.CreateFunctionQuery<%s>("%s.%s", true%s);\n', clrType, MetadataNamespace, operationName, paramsStr) :
 			util.format('\
 \n\
-            return new %sSingle(source.CreateFunctionQuerySingle<%s>("%s.%s", true%s));\n', clrType, clrType, constants.Code.DefaultNamespace, operationName, paramsStr);
+            return new %sSingle(source.CreateFunctionQuerySingle<%s>("%s.%s", true%s));\n', clrType, clrType, MetadataNamespace, operationName, paramsStr);
 	}
 
 	return returnsStr;
@@ -829,208 +829,7 @@ function genExBoundOperation(operation, boundParam, namespaceName){
 \n\
             return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
                 source.Context,\n\
-                source.AppendRequestUri("%s.%s")', constants.Code.DefaultNamespace, operationName);
-			if(operation.params && operation.params.length > 0){
-				for(var j = 0; j < operation.params.length; j++){
-				    operationBody += util.format('\
-,\n\
-                new global::Microsoft.OData.Client.BodyOperationParameter("%s", %s)', operation.params[j].name, operation.params[j].name);
-			    }
-			}
-			
-			operationBody += ');\n';
-		}
-
-		operationFrame = util.format('\
-        /// <summary>\n\
-        /// There are no comments for %s in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("%s")]\n\
-        public static %s %s(%s)\n\
-        {\n\
-%s\
-        }\n', operationName, operationName, operationType, operationName, operationParams, operationBody);
-	}
-
-	return operationFrame;
-}
-
-exports.genExBoundOperations = genExBoundOperations;
-function genExBoundOperations(entityType, namespaceName){
-	var boundParam = entityType.name;
-	var props = entityType.properties;
-	var result = '';
-	for(var i = 0; i < props.length; i++){
-		if(props[i].type === 'Function' || props[i].type === 'Action'){
-			result += genExBoundOperation(props[i], boundParam, namespaceName) + '\n';
-		}
-	}
-
-	return result;
-}
-
-exports.genExtensionMethods = genExtensionMethods;
-function genExtensionMethods(methods){
-	var result = '\
-    /// <summary>\n\
-    /// Class containing all extension methods\n\
-    /// </summary>\n\
-    public static class ExtensionMethods\n\
-    {\n';
-	result += methods;
-	result += '\
-    }\n';
-
-	return result;
-}
-
-function getCLRType(type, namespaceName){
-	var typeInfo = typeMaps.MapType(type.type);
-	var clrType = typeInfo.type;
-
-	if(typeInfo.isPrimitive === false){
-		clrType = util.format('global::%s.%s', namespaceName, typeInfo.type);
-	}
-	
-	if(typeInfo.isPrimitive && typeInfo.isRefType === false && type.isNullable && type.isNullable === true){
-		clrType = util.format('global::System.Nullable<%s>', typeInfo.type);
-	}
-
-	return clrType;
-}
-
-function getExBoundOpOperationCLRType(type, namespaceName){
-	var typeInfo = typeMaps.MapType(type.type);
-	var clrType = getCLRType(type, namespaceName);
-	if(typeInfo.isPrimitive === true){
-		// Process primitive-type.
-		clrType = type.isCollection && type.isCollection === true ?
-			util.format('global::Microsoft.OData.Client.DataServiceQuery<%s>', clrType) :
-			util.format('global::Microsoft.OData.Client.DataServiceQuerySingle<%s>', clrType);
-	}
-	else{ // isPrimitive === false
-		// Process entity-type.
-		clrType = type.isCollection && type.isCollection === true ?
-			util.format('global::Microsoft.OData.Client.DataServiceQuery<%s>', clrType) :
-			util.format('%sSingle', clrType);
-	}
-
-	return clrType;
-}
-
-function getExBoundOpParameterCLRType(type, namespaceName){
-	var typeInfo = typeMaps.MapType(type.type);
-	var clrType = getCLRType(type, namespaceName);
-	if(typeInfo.isPrimitive === true){
-		// Process primitive-type.
-		clrType = type.isCollection && type.isCollection === true ?
-			util.format('global::System.Collections.Generic.ICollection<%s>', clrType) :
-			clrType;
-	}
-	else{ // isPrimitive === false
-		// Process entity-type.
-		clrType = type.isCollection && type.isCollection === true ?
-			util.format('global::System.Collections.Generic.ICollection<%s>', clrType) :
-			util.format('%s', clrType);
-	}
-
-	return clrType;
-}
-
-function getExBoundOpParams(boundParam, params, namespaceName, opType){
-	var type = { type: boundParam };
-	var paramsStr = util.format('this global::Microsoft.OData.Client.DataServiceQuerySingle<%s> source', getCLRType(type, namespaceName));
-	var containsEntityType = false;
-	var isCollection = false;
-	if(params && params.length > 0){
-		for(var i = 0; i < params.length; i++){
-			var clrType = typeMaps.MapType(params[i].type);
-			if(clrType.isPrimitive === false && containsEntityType === false){
-				containsEntityType = true;
-				isCollection = params[i].isCollection && params[i].isCollection;
-			}
-			paramsStr += util.format(', %s %s',
-				getExBoundOpParameterCLRType(params[i], namespaceName),
-				params[i].name);
-		}
-	}
-	// Maybe there has a bug in T4 template.
-	return containsEntityType && opType && opType === 'Function' ? 
-		paramsStr + (isCollection ? ', bool useEntityReference = true' : ', bool useEntityReference = false') : 
-		paramsStr;
-}
-
-function getExBoundFuncReturns(returns, namespaceName, operationName, paramsStr){
-	var returnsStr = '';
-	var typeInfo = typeMaps.MapType(returns.type);
-	var clrType = getCLRType(returns, namespaceName);
-	if(typeInfo.isPrimitive === true){
-		// Process primitive-type.
-		returnsStr = returns.isCollection && returns.isCollection === true ?
-			util.format('\
-\n\
-            return source.CreateFunctionQuery<%s>("%s.%s", true%s);\n', clrType, constants.Code.DefaultNamespace, operationName, paramsStr) :
-			util.format('\
-\n\
-            return source.CreateFunctionQuerySingle<%s>("%s.%s", true%s);\n', clrType, constants.Code.DefaultNamespace, operationName, paramsStr);
-	}
-	else{ // isPrimitive === false
-		// Process entity-type.
-		returnsStr = returns.isCollection && returns.isCollection === true ?
-			util.format('\
-\n\
-            return source.CreateFunctionQuery<%s>("%s.%s", true%s);\n', clrType, constants.Code.DefaultNamespace, operationName, paramsStr) :
-			util.format('\
-\n\
-            return new %sSingle(source.CreateFunctionQuerySingle<%s>("%s.%s", true%s));\n', clrType, clrType, constants.Code.DefaultNamespace, operationName, paramsStr);
-	}
-
-	return returnsStr;
-}
-
-exports.genExBoundOperation = genExBoundOperation;
-function genExBoundOperation(operation, boundParam, namespaceName){
-	var result = '';
-	var operationFrame = '';
-	if(operation && operation.operationType === 'Bound'){
-		var operationName = StringHelper.capitalizeInitial(operation.name);
-		var operationParams = getExBoundOpParams(boundParam, operation.params, namespaceName, operation.type);
-		var operationType = '';
-		var operationBody = '\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n';
-		if(operation.type === 'Function'){
-			if(operation.returns){
-				var paramsStr = '';
-				if(operation.params && operation.params.length > 0){
-					for(var i = 0; i < operation.params.length; i++){
-						var clrType = typeMaps.MapType(operation.params[i].type);
-						if(clrType.isPrimitive){
-							paramsStr += util.format(', new global::Microsoft.OData.Client.UriOperationParameter("%s", %s)', operation.params[i].name, operation.params[i].name);
-						}
-						else{
-							paramsStr += util.format(', new global::Microsoft.OData.Client.UriEntityOperationParameter("%s", %s, useEntityReference)', operation.params[i].name, operation.params[i].name);
-						}
-					}
-				}
-				operationType = getExBoundOpOperationCLRType(operation.returns, namespaceName);
-				operationBody += getExBoundFuncReturns(operation.returns, namespaceName, operationName, paramsStr);
-			}
-			else{
-				console.error('The unbound function %s must have a return value.', operationName);
-
-				return '';
-			}
-		}
-		else{ // operation.type === Action
-			operationType = 'global::Microsoft.OData.Client.DataServiceActionQuery';
-			operationBody += util.format('\
-\n\
-            return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
-                source.Context,\n\
-                source.AppendRequestUri("%s.%s")', constants.Code.DefaultNamespace, operationName);
+                source.AppendRequestUri("%s.%s")', MetadataNamespace, operationName);
 			if(operation.params && operation.params.length > 0){
 				for(var j = 0; j < operation.params.length; j++){
 				    operationBody += util.format('\

--- a/test/codegen/csharpClientCodegenSpec.js
+++ b/test/codegen/csharpClientCodegenSpec.js
@@ -1435,7 +1435,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
                 throw new global::System.NotSupportedException("The previous function is not composable.");\n\
             }\n\
 \n\
-            return source.CreateFunctionQuerySingle<string>("' + constants.Code.DefaultNamespace + '.MyFunction1", true, new global::Microsoft.OData.Client.UriOperationParameter("tripId", tripId));\n\
+            return source.CreateFunctionQuerySingle<string>("Microsoft.OData.SampleService.Models.TripPin.MyFunction1", true, new global::Microsoft.OData.Client.UriOperationParameter("tripId", tripId));\n\
         }\n\
 \n';
 
@@ -1479,7 +1479,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
                 throw new global::System.NotSupportedException("The previous function is not composable.");\n\
             }\n\
 \n\
-            return source.CreateFunctionQuery<string>("' + constants.Code.DefaultNamespace + '.MyFunction2", true, new global::Microsoft.OData.Client.UriOperationParameter("tripIds", tripIds));\n\
+            return source.CreateFunctionQuery<string>("Microsoft.OData.SampleService.Models.TripPin.MyFunction2", true, new global::Microsoft.OData.Client.UriOperationParameter("tripIds", tripIds));\n\
         }\n\
 \n';
 
@@ -1520,7 +1520,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
                 throw new global::System.NotSupportedException("The previous function is not composable.");\n\
             }\n\
 \n\
-            return new global::' + namespaceName + '.PersonSingle(source.CreateFunctionQuerySingle<global::' + namespaceName + '.Person>("' + constants.Code.DefaultNamespace + '.MyFunction3", true, new global::Microsoft.OData.Client.UriEntityOperationParameter("trip", trip, useEntityReference)));\n\
+            return new global::' + namespaceName + '.PersonSingle(source.CreateFunctionQuerySingle<global::' + namespaceName + '.Person>("Microsoft.OData.SampleService.Models.TripPin.MyFunction3", true, new global::Microsoft.OData.Client.UriEntityOperationParameter("trip", trip, useEntityReference)));\n\
         }\n\
 \n';
 
@@ -1563,7 +1563,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
                 throw new global::System.NotSupportedException("The previous function is not composable.");\n\
             }\n\
 \n\
-            return source.CreateFunctionQuery<global::' + namespaceName + '.Person>("' + constants.Code.DefaultNamespace + '.MyFunction4", true, new global::Microsoft.OData.Client.UriEntityOperationParameter("trips", trips, useEntityReference));\n\
+            return source.CreateFunctionQuery<global::' + namespaceName + '.Person>("Microsoft.OData.SampleService.Models.TripPin.MyFunction4", true, new global::Microsoft.OData.Client.UriEntityOperationParameter("trips", trips, useEntityReference));\n\
         }\n\
 \n';
         var actual = genExBoundOperations(entityType, namespaceName);
@@ -1602,7 +1602,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
 \n\
             return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
                 source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction1"),\n\
+                source.AppendRequestUri("Microsoft.OData.SampleService.Models.TripPin.MyAction1"),\n\
                 new global::Microsoft.OData.Client.BodyOperationParameter("tripId", tripId));\n\
         }\n\
 \n';
@@ -1643,7 +1643,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
 \n\
             return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
                 source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction2"),\n\
+                source.AppendRequestUri("Microsoft.OData.SampleService.Models.TripPin.MyAction2"),\n\
                 new global::Microsoft.OData.Client.BodyOperationParameter("tripIds", tripIds));\n\
         }\n\
 \n';
@@ -1683,7 +1683,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
 \n\
             return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
                 source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction3"),\n\
+                source.AppendRequestUri("Microsoft.OData.SampleService.Models.TripPin.MyAction3"),\n\
                 new global::Microsoft.OData.Client.BodyOperationParameter("trip", trip));\n\
         }\n\
 \n';
@@ -1723,336 +1723,7 @@ describe('[OData Service Client Codegen: CSharp] Test', function () {
 \n\
             return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
                 source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction4"),\n\
-                new global::Microsoft.OData.Client.BodyOperationParameter("trips", trips));\n\
-        }\n\
-\n';
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound functions with primitive type parameters and primitive type returns.', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myFunction1',
-                    type: 'Function',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'tripId',
-                          type: 'edm.int32'
-                      }
-                    ],
-                    returns: {
-                        type: 'edm.string'
-                    }
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyFunction1 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyFunction1")]\n\
-        public static global::Microsoft.OData.Client.DataServiceQuerySingle<string> MyFunction1(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, int tripId)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return source.CreateFunctionQuerySingle<string>("' + constants.Code.DefaultNamespace + '.MyFunction1", true, new global::Microsoft.OData.Client.UriOperationParameter("tripId", tripId));\n\
-        }\n\
-\n';
-
-        var actual = genExBoundOperations(entityType, namespaceName);
-
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound functions with collection of primitive type parameters and collection of primitive type returns', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myFunction2',
-                    type: 'Function',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'tripIds',
-                          type: 'edm.int32',
-                          isCollection: true
-                      }
-                    ],
-                    returns: {
-                        type: 'edm.string',
-                        isCollection: true
-                    }
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyFunction2 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyFunction2")]\n\
-        public static global::Microsoft.OData.Client.DataServiceQuery<string> MyFunction2(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, global::System.Collections.Generic.ICollection<int> tripIds)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return source.CreateFunctionQuery<string>("' + constants.Code.DefaultNamespace + '.MyFunction2", true, new global::Microsoft.OData.Client.UriOperationParameter("tripIds", tripIds));\n\
-        }\n\
-\n';
-
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound functions with entity type parameters and entity type returns', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myFunction3',
-                    type: 'Function',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'trip',
-                          type: 'trip'
-                      }
-                    ],
-                    returns: {
-                        type: 'person'
-                    }
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyFunction3 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyFunction3")]\n\
-        public static global::' + namespaceName + '.PersonSingle MyFunction3(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, global::' + namespaceName + '.Trip trip, bool useEntityReference = false)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return new global::' + namespaceName + '.PersonSingle(source.CreateFunctionQuerySingle<global::' + namespaceName + '.Person>("' + constants.Code.DefaultNamespace + '.MyFunction3", true, new global::Microsoft.OData.Client.UriEntityOperationParameter("trip", trip, useEntityReference)));\n\
-        }\n\
-\n';
-
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound functions with collection of entity type parameters and collection of entity type returns', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myFunction4',
-                    type: 'Function',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'trips',
-                          type: 'trip',
-                          isCollection: true
-                      }
-                    ],
-                    returns: {
-                        type: 'person',
-                        isCollection: true
-                    }
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyFunction4 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyFunction4")]\n\
-        public static global::Microsoft.OData.Client.DataServiceQuery<global::' + namespaceName + '.Person> MyFunction4(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, global::System.Collections.Generic.ICollection<global::' + namespaceName + '.Trip> trips, bool useEntityReference = true)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return source.CreateFunctionQuery<global::' + namespaceName + '.Person>("' + constants.Code.DefaultNamespace + '.MyFunction4", true, new global::Microsoft.OData.Client.UriEntityOperationParameter("trips", trips, useEntityReference));\n\
-        }\n\
-\n';
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound actions with primitive type parameters', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myAction1',
-                    type: 'Action',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'tripId',
-                          type: 'edm.int32'
-                      }
-                    ]
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyAction1 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyAction1")]\n\
-        public static global::Microsoft.OData.Client.DataServiceActionQuery MyAction1(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, int tripId)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
-                source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction1"),\n\
-                new global::Microsoft.OData.Client.BodyOperationParameter("tripId", tripId));\n\
-        }\n\
-\n';
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound actions with collection of primitive type parameters', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myAction2',
-                    type: 'Action',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'tripIds',
-                          type: 'edm.int32',
-                          isCollection: true
-                      }
-                    ]
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyAction2 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyAction2")]\n\
-        public static global::Microsoft.OData.Client.DataServiceActionQuery MyAction2(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, global::System.Collections.Generic.ICollection<int> tripIds)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
-                source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction2"),\n\
-                new global::Microsoft.OData.Client.BodyOperationParameter("tripIds", tripIds));\n\
-        }\n\
-\n';
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound actions with entity type parameters', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myAction3',
-                    type: 'Action',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'trip',
-                          type: 'trip'
-                      }
-                    ]
-                }
-            ]
-        };
-
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyAction3 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyAction3")]\n\
-        public static global::Microsoft.OData.Client.DataServiceActionQuery MyAction3(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, global::' + namespaceName + '.Trip trip)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
-                source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction3"),\n\
-                new global::Microsoft.OData.Client.BodyOperationParameter("trip", trip));\n\
-        }\n\
-\n';
-        var actual = genExBoundOperations(entityType, namespaceName);
-        expect(actual).toEqual(expected);
-    });
-
-    it('generation for extension bound actions with collection of entity type parameters', function () {
-        var entityType = {
-            name: 'person',
-            properties: [
-                {
-                    name: 'myAction4',
-                    type: 'Action',
-                    operationType: 'Bound',
-                    params: [
-                      {
-                          name: 'trips',
-                          type: 'trip',
-                          isCollection: true
-                      }
-                    ]
-                }
-            ]
-        };
-        var expected = '\
-        /// <summary>\n\
-        /// There are no comments for MyAction4 in the schema.\n\
-        /// </summary>\n\
-        [global::Microsoft.OData.Client.OriginalNameAttribute("MyAction4")]\n\
-        public static global::Microsoft.OData.Client.DataServiceActionQuery MyAction4(this global::Microsoft.OData.Client.DataServiceQuerySingle<global::' + namespaceName + '.Person> source, global::System.Collections.Generic.ICollection<global::' + namespaceName + '.Trip> trips)\n\
-        {\n\
-            if (!source.IsComposable)\n\
-            {\n\
-                throw new global::System.NotSupportedException("The previous function is not composable.");\n\
-            }\n\
-\n\
-            return new global::Microsoft.OData.Client.DataServiceActionQuery(\n\
-                source.Context,\n\
-                source.AppendRequestUri("' + constants.Code.DefaultNamespace + '.MyAction4"),\n\
+                source.AppendRequestUri("Microsoft.OData.SampleService.Models.TripPin.MyAction4"),\n\
                 new global::Microsoft.OData.Client.BodyOperationParameter("trips", trips));\n\
         }\n\
 \n';


### PR DESCRIPTION
1.Split bound function namespaces, following current MetadataNamespace default value hard coded design. 
New design will be raised in mail to discuss. 
2.delete duplicate bound function csharp codeGen codes and 8 duplicate cases.